### PR TITLE
Fixed some of your issues

### DIFF
--- a/src/main/java/org/frizzlenpop/rPGSkillsPlugin/RPGSkillsPlugin.java
+++ b/src/main/java/org/frizzlenpop/rPGSkillsPlugin/RPGSkillsPlugin.java
@@ -38,7 +38,6 @@ public class RPGSkillsPlugin extends JavaPlugin {
         this.skillsGUI = new SkillsGUI(playerDataManager, xpManager, abilityManager, passiveSkillManager);
 
 
-
         // Set the passive skill manager after initialization
         xpManager.setPassiveSkillManager(passiveSkillManager);
 
@@ -47,6 +46,7 @@ public class RPGSkillsPlugin extends JavaPlugin {
         getCommand("abilities").setExecutor(new AbilitiesCommand(this, playerDataManager));
         getCommand("skillsadmin").setExecutor(new SkillsAdminCommand(playerDataManager, xpManager));
         getCommand("toggleskillmessages").setExecutor(new ToggleSkillMessagesCommand(playerDataManager));
+        getCommand("passives").setExecutor(new PassivesCommand(passiveSkillManager));
 
         // Register all listeners
         registerListeners();
@@ -62,6 +62,8 @@ public class RPGSkillsPlugin extends JavaPlugin {
         getServer().getPluginManager().registerEvents(skillsGUI, this);
         getServer().getPluginManager().registerEvents(new LoggingListener(xpManager), this);
         getServer().getPluginManager().registerEvents(new FarmingListener(xpManager), this);
+
+        getServer().getPluginManager().registerEvents(abilityManager, this);
     }
 
 
@@ -113,7 +115,8 @@ public class RPGSkillsPlugin extends JavaPlugin {
         // Save player data
         if (playerDataManager != null) {
             for (Player player : getServer().getOnlinePlayers()) {
-                playerDataManager.savePlayerData(player.getUniqueId(), null);
+                FileConfiguration playerData = playerDataManager.getPlayerData(player.getUniqueId());
+                playerDataManager.savePlayerData(player.getUniqueId(), playerData);
             }
         }
 

--- a/src/main/java/org/frizzlenpop/rPGSkillsPlugin/skills/SkillAbilityManager.java
+++ b/src/main/java/org/frizzlenpop/rPGSkillsPlugin/skills/SkillAbilityManager.java
@@ -67,7 +67,9 @@ public class SkillAbilityManager implements Listener {
     public void activateTimberChop(Player player) {
         if (canUseAbility(player, "TimberChop", 30)) {
             player.sendMessage("§a[Skill] Timber Chop activated! The next tree you break will fall instantly.");
+
             timberChopPlayers.add(player.getUniqueId());
+            Bukkit.broadcastMessage(Arrays.toString(timberChopPlayers.toArray()));
         }
     }
 
@@ -77,29 +79,38 @@ public class SkillAbilityManager implements Listener {
         Block block = event.getBlock();
 
         if (timberChopPlayers.contains(player.getUniqueId()) && isLog(block.getType())) {
+            Bukkit.broadcastMessage("Block broken: " + block.getType());
             chopTree(block);
             timberChopPlayers.remove(player.getUniqueId());
         }
     }
 
     private boolean isLog(Material material) {
-        return material.name().endsWith("_LOG"); // Works for all wood types
+        return material.name().contains("_LOG"); // Works for all wood types
     }
 
     private void chopTree(Block block) {
         Queue<Block> logsToBreak = new LinkedList<>();
+        Set<Block> visited = new HashSet<>();
+
         logsToBreak.add(block);
+        visited.add(block);
 
         while (!logsToBreak.isEmpty()) {
             Block current = logsToBreak.poll();
             if (isLog(current.getType())) {
                 current.breakNaturally();
+
                 for (Block relative : getAdjacentBlocks(current)) {
-                    logsToBreak.add(relative);
+                    if (!visited.contains(relative) && isLog(relative.getType())) {
+                        logsToBreak.add(relative);
+                        visited.add(relative);
+                    }
                 }
             }
         }
     }
+
 
     private List<Block> getAdjacentBlocks(Block block) {
         List<Block> adjacent = new ArrayList<>();
@@ -126,15 +137,13 @@ public class SkillAbilityManager implements Listener {
     public void activateAbility(Player player, String ability) {
         switch (ability) {
             case "Mining Burst":
-                player.sendMessage("§a[Skill] Mining Burst activated!");
-                player.addPotionEffect(new PotionEffect(PotionEffectType.HASTE, 5 * 20, 2));
+                activateMiningBurst(player);
                 break;
             case "Timber Chop":
-                player.sendMessage("§a[Skill] Timber Chop activated!");
+                activateTimberChop(player);
                 break;
             case "Berserker Rage":
-                player.sendMessage("§a[Skill] Berserker Rage activated!");
-                player.addPotionEffect(new PotionEffect(PotionEffectType.STRENGTH, 10 * 20, 1));
+                activateBerserkerRage(player);
                 break;
         }
     }


### PR DESCRIPTION
# 🛠 Bug Fixes & Improvements
## 🐛 Bugs:
- Ores without a smelted variant failed to drop their normal item.
- The **Double Ore Drop** passive skill was missing an implementation.
- The **Passive** command was not registered.
- Player data was not saving properly in the `onDisable` method.
- Passive names were in **snake_case**, causing the `hasPassive` method to fail.
- The **activateAbility** method did not trigger the corresponding ability function.

## ✅ Fixes:
- Implemented a method to ensure ores without a smelted variant drop correctly.
- Added a **50% chance** for the **Double Ore Drop** passive (for testing).
- Registered the **Passive** command to allow for easier testing.
- Fixed a **null `config` issue** by correctly passing in `playerdata` for saving.
- Renamed passive skills from **snake_case** to **camelCase** for proper detection.
- Updated `activateAbility` to correctly call ability functions, fixing issues with **Timber Chop** and **Berserker Rage**.